### PR TITLE
Showing

### DIFF
--- a/src/Data/Name.hs
+++ b/src/Data/Name.hs
@@ -16,9 +16,7 @@ instance Show Name where
   show (Global name) = name
 
 freshBy :: (Name -> Bool) -> Name -> Name
-freshBy used name | used name = case name of
-  Local i -> freshBy used (Local $ i + 1)
-  Global n -> freshBy used (Global $ n ++ "'")
+freshBy used name | used name = freshBy used (prime name)
 freshBy _ name = name
 
 fresh :: Set Name -> Name -> Name

--- a/src/Data/Name.hs
+++ b/src/Data/Name.hs
@@ -2,6 +2,7 @@ module Data.Name (
   Name(..),
   freshBy,
   fresh,
+  prime,
 ) where
 
 import Data.Name.Internal
@@ -22,3 +23,7 @@ freshBy _ name = name
 
 fresh :: Set Name -> Name -> Name
 fresh set = freshBy (`member` set)
+
+prime :: Name -> Name
+prime (Local i) = Local $ i + 1
+prime (Global n) = Global $ n ++ "ʹ"

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -38,3 +38,7 @@ substitute name with (Term _ binding) = case binding of
 
 cata :: Functor f => (Binding f a -> a) -> Term f -> a
 cata f = f . fmap (cata f) . out
+
+para :: Functor f => (Binding f (Term f, a) -> a) -> Term f -> a
+para f = f . fmap fanout . out
+  where fanout a = (a, para f a)

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -36,5 +36,5 @@ substitute name with (Term _ binding) = case binding of
           body' = substitute name with (rename name name' body)
   Expression body -> expression $ substitute name with <$> body
 
-cata :: (Functor f) => (Binding f a -> a) -> Term f -> a
+cata :: Functor f => (Binding f a -> a) -> Term f -> a
 cata f = f . fmap (cata f) . out

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -36,6 +36,8 @@ instance Show (Term Expression) where
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, -1)
     Expression (Application a b) -> (fst a ++ " " ++ fst b, 4)
     Expression e -> (show e, -1))
+    where wrap i (s, j) | i > j = s
+          wrap i (s, _) = "(" ++ s ++ ")"
 
 instance Eq (Term Expression) where
   a == b = freeVariables a == freeVariables b && out a == out b

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -41,7 +41,7 @@ instance Show (Term Expression) where
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
     Expression (Lambda (_, type') (Term _ (Abstraction name (Term free _)), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
-    Expression (Lambda (_, type') (Term _ (Abstraction _ _), body)) -> ("λ _ . " ++ wrap 3 (<=) body, 3)
+    Expression (Lambda (_, type') (Term _ (Abstraction _ _), body)) -> ("λ _ : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
     Expression (Lambda (_, type') (_, body)) -> (wrap 3 (<) type' ++ " → " ++ wrap 3 (<=) body, 3)
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -2,6 +2,7 @@
 module Surface (
   module Surface',
   lambda,
+  (-->),
   _type,
   _type',
   apply,
@@ -19,6 +20,9 @@ lambda :: Term Expression -> (Term Expression -> Term Expression) -> Term Expres
 lambda t f = expression . Lambda t $ abstraction name body
   where body = f $ variable name
         name = Maybe.fromMaybe (Local 0) $ maxBoundVariable body
+
+(-->) :: Term Expression -> Term Expression -> Term Expression
+a --> b = expression $ Lambda a b
 
 _type :: Int -> Term Expression
 _type n = expression $ Type n

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -36,7 +36,7 @@ instance Show (Term Expression) where
     Expression (Type 0) -> ("Type", maxBound)
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
-    Expression (Lambda (_, type') (Term free (Abstraction name _), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<=) type' ++ " . " ++ wrap 3 (<) body, 3)
+    Expression (Lambda (_, type') (Term _ (Abstraction name (Term free _)), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<=) type' ++ " . " ++ wrap 3 (<) body, 3)
     Expression (Lambda (_, type') (_, body)) -> ("λ . " ++ wrap 3 (<) body, 3)
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -41,7 +41,8 @@ instance Show (Term Expression) where
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
     Expression (Lambda (_, type') (Term _ (Abstraction name (Term free _)), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
-    Expression (Lambda (_, type') (_, body)) -> ("λ . " ++ wrap 3 (<=) body, 3)
+    Expression (Lambda (_, type') (Term _ (Abstraction _ _), body)) -> ("λ . " ++ wrap 3 (<=) body, 3)
+    Expression (Lambda (_, type') (_, body)) -> (wrap 3 (<) type' ++ " → " ++ wrap 3 (<=) body, 3)
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s
           wrap i _ (s, _) = "(" ++ s ++ ")"

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -36,7 +36,7 @@ instance Show (Term Expression) where
     Expression (Type 0) -> ("Type", maxBound)
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
-    Expression (Lambda (_, type') (Term _ (Abstraction name (Term free _)), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<=) type' ++ " . " ++ wrap 3 (<) body, 3)
+    Expression (Lambda (_, type') (Term _ (Abstraction name (Term free _)), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
     Expression (Lambda (_, type') (_, body)) -> ("λ . " ++ wrap 3 (<) body, 3)
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -30,12 +30,13 @@ apply a b = expression $ Application a b
 
 instance Show (Term Expression) where
   show = fst . para (\ b -> case b of
-    Variable n -> (show n, maxBound :: Int)
+    Variable n -> (show n, maxBound)
     Abstraction _ (_, body) -> body
     Expression (Type 0) -> ("Type", maxBound)
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
-    Expression e -> (show e, -1))
+    Expression e -> (show e, -1)
+    :: (String, Int))
     where wrap i op (s, j) | i `op` j = s
           wrap i _ (s, _) = "(" ++ s ++ ")"
 

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -13,6 +13,7 @@ import Data.Name as Surface'
 import Data.Name.Internal
 import Data.Term as Surface'
 import qualified Data.Maybe as Maybe
+import qualified Data.Set as Set
 
 lambda :: Term Expression -> (Term Expression -> Term Expression) -> Term Expression
 lambda t f = expression . Lambda t $ abstraction name body
@@ -35,6 +36,7 @@ instance Show (Term Expression) where
     Expression (Type 0) -> ("Type", maxBound)
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
+    Expression (Lambda (_, type') (Term free (Abstraction name _), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<=) type' ++ " . " ++ wrap 3 (<) body, 3)
     Expression e -> (show e, -1)
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE FlexibleInstances #-}
 module Surface (
-  module Surface,
+  module Surface',
+  lambda,
+  _type,
+  _type',
+  apply,
 ) where
 
-import Data.Binding as Surface
-import Data.Expression as Surface
-import Data.Name as Surface
+import Data.Binding as Surface'
+import Data.Expression as Surface'
+import Data.Name as Surface'
 import Data.Name.Internal
-import Data.Term as Surface
+import Data.Term as Surface'
 import qualified Data.Maybe as Maybe
 
 lambda :: Term Expression -> (Term Expression -> Term Expression) -> Term Expression

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -29,13 +29,13 @@ apply :: Term Expression -> Term Expression -> Term Expression
 apply a b = expression $ Application a b
 
 instance Show (Term Expression) where
-  show = cata $ \ b -> case b of
-    Variable n -> show n
-    Abstraction _ body -> show body
-    Expression (Type 0) -> "Type"
-    Expression (Type n) -> "Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n
-    Expression (Application a b) -> a ++ " " ++ b
-    Expression e -> show e
+  show = fst . cata (\ b -> case b of
+    Variable n -> (show n, -1)
+    Abstraction _ body -> body
+    Expression (Type 0) -> ("Type", -1)
+    Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, -1)
+    Expression (Application a b) -> (fst a ++ " " ++ fst b, 4)
+    Expression e -> (show e, -1))
 
 instance Eq (Term Expression) where
   a == b = freeVariables a == freeVariables b && out a == out b

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -41,7 +41,7 @@ instance Show (Term Expression) where
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
     Expression (Lambda (_, type') (Term _ (Abstraction name (Term free _)), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
-    Expression (Lambda (_, type') (_, body)) -> ("λ . " ++ wrap 3 (<) body, 3)
+    Expression (Lambda (_, type') (_, body)) -> ("λ . " ++ wrap 3 (<=) body, 3)
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s
           wrap i _ (s, _) = "(" ++ s ++ ")"

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -37,12 +37,16 @@ instance Show (Term Expression) where
   show = fst . para (\ b -> case b of
     Variable n -> (show n, maxBound)
     Abstraction _ (_, body) -> body
+
     Expression (Type 0) -> ("Type", maxBound)
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
+
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
+
     Expression (Lambda (_, type') (Term _ (Abstraction name (Term free _)), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
     Expression (Lambda (_, type') (Term _ (Abstraction _ _), body)) -> ("λ _ : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
     Expression (Lambda (_, type') (_, body)) -> (wrap 3 (<) type' ++ " → " ++ wrap 3 (<=) body, 3)
+
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s
           wrap i _ (s, _) = "(" ++ s ++ ")"

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -30,6 +30,7 @@ instance Show (Term Expression) where
     Abstraction _ body -> show body
     Expression (Type 0) -> "Type"
     Expression (Type n) -> "Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n
+    Expression (Application a b) -> a ++ " " ++ b
     Expression e -> show e
 
 instance Eq (Term Expression) where

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -37,7 +37,7 @@ instance Show (Term Expression) where
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
     Expression (Lambda (_, type') (Term free (Abstraction name _), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<=) type' ++ " . " ++ wrap 3 (<) body, 3)
-    Expression e -> (show e, -1)
+    Expression (Lambda (_, type') (_, body)) -> ("λ . " ++ wrap 3 (<) body, 3)
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s
           wrap i _ (s, _) = "(" ++ s ++ ")"

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -19,7 +19,7 @@ import qualified Data.Set as Set
 lambda :: Term Expression -> (Term Expression -> Term Expression) -> Term Expression
 lambda t f = expression . Lambda t $ abstraction name body
   where body = f $ variable name
-        name = Maybe.fromMaybe (Local 0) $ maxBoundVariable body
+        name = maybe (Local 0) prime $ maxBoundVariable body
 
 (-->) :: Term Expression -> Term Expression -> Term Expression
 a --> b = expression $ Lambda a b

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -29,12 +29,12 @@ apply :: Term Expression -> Term Expression -> Term Expression
 apply a b = expression $ Application a b
 
 instance Show (Term Expression) where
-  show = fst . cata (\ b -> case b of
+  show = fst . para (\ b -> case b of
     Variable n -> (show n, -1)
-    Abstraction _ body -> body
+    Abstraction _ (_, body) -> body
     Expression (Type 0) -> ("Type", -1)
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, -1)
-    Expression (Application a b) -> (wrap 5 a ++ " " ++ wrap 4 b, 4)
+    Expression (Application (_, a) (_, b)) -> (wrap 5 a ++ " " ++ wrap 4 b, 4)
     Expression e -> (show e, -1))
     where wrap i (s, j) | i > j = s
           wrap i (s, _) = "(" ++ s ++ ")"

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -34,7 +34,7 @@ instance Show (Term Expression) where
     Abstraction _ body -> body
     Expression (Type 0) -> ("Type", -1)
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, -1)
-    Expression (Application a b) -> (fst a ++ " " ++ fst b, 4)
+    Expression (Application a b) -> (wrap 5 a ++ " " ++ wrap 4 b, 4)
     Expression e -> (show e, -1))
     where wrap i (s, j) | i > j = s
           wrap i (s, _) = "(" ++ s ++ ")"

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -34,10 +34,10 @@ instance Show (Term Expression) where
     Abstraction _ (_, body) -> body
     Expression (Type 0) -> ("Type", -1)
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, -1)
-    Expression (Application (_, a) (_, b)) -> (wrap 5 a ++ " " ++ wrap 4 b, 4)
+    Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
     Expression e -> (show e, -1))
-    where wrap i (s, j) | i > j = s
-          wrap i (s, _) = "(" ++ s ++ ")"
+    where wrap i op (s, j) | i `op` j = s
+          wrap i _ (s, _) = "(" ++ s ++ ")"
 
 instance Eq (Term Expression) where
   a == b = freeVariables a == freeVariables b && out a == out b

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -41,7 +41,7 @@ instance Show (Term Expression) where
     Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
     Expression (Lambda (_, type') (Term _ (Abstraction name (Term free _)), body)) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
-    Expression (Lambda (_, type') (Term _ (Abstraction _ _), body)) -> ("λ . " ++ wrap 3 (<=) body, 3)
+    Expression (Lambda (_, type') (Term _ (Abstraction _ _), body)) -> ("λ _ . " ++ wrap 3 (<=) body, 3)
     Expression (Lambda (_, type') (_, body)) -> (wrap 3 (<) type' ++ " → " ++ wrap 3 (<=) body, 3)
     :: (String, Int))
     where wrap i op (s, j) | i `op` j = s

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -30,10 +30,10 @@ apply a b = expression $ Application a b
 
 instance Show (Term Expression) where
   show = fst . para (\ b -> case b of
-    Variable n -> (show n, -1)
+    Variable n -> (show n, maxBound :: Int)
     Abstraction _ (_, body) -> body
-    Expression (Type 0) -> ("Type", -1)
-    Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, -1)
+    Expression (Type 0) -> ("Type", maxBound)
+    Expression (Type n) -> ("Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n, maxBound)
     Expression (Application (_, a) (_, b)) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
     Expression e -> (show e, -1))
     where wrap i op (s, j) | i `op` j = s

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -29,7 +29,7 @@ instance Show (Term Expression) where
     Variable n -> show n
     Abstraction _ body -> show body
     Expression (Type 0) -> "Type"
-    Expression (Type n) -> "Type" ++ showNumeral "0123456789" n
+    Expression (Type n) -> "Type" ++ showNumeral "₀₁₂₃₄₅₆₇₈₉" n
     Expression e -> show e
 
 instance Eq (Term Expression) where

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -32,6 +32,9 @@ main = hspec $ do
     it "associates applications to the left without parentheses" $
       show (apply (apply (variable (Local 0)) (variable (Local 1))) (variable (Local 2))) `shouldBe` "a b c"
 
+    it "parenthesizes right-nested applications" $
+      show (apply (variable (Local 0)) (apply (variable (Local 1)) (variable (Local 2)))) `shouldBe` "a (b c)"
+
   describe "digits" $ do
     it "zero is zero in base 10" $
       digits 10 0 `shouldBe` [0]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -15,13 +15,13 @@ main = hspec $ do
       show _type' `shouldBe` "Type"
 
     it "shows Type (n > 0) with subscript" $
-      show (_type 1) `shouldBe` "Type1"
+      show (_type 1) `shouldBe` "Type₁"
 
     it "shows Type (n > 9) with subscript digits" $
-      show (_type 10) `shouldBe` "Type10"
+      show (_type 10) `shouldBe` "Type₁₀"
 
     it "shows Type (n > 10) with subscript digits" $
-      show (_type 12) `shouldBe` "Type12"
+      show (_type 12) `shouldBe` "Type₁₂"
 
   describe "digits" $ do
     it "zero is zero in base 10" $

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -35,6 +35,9 @@ main = hspec $ do
     it "parenthesizes right-nested applications" $
       show (apply (variable (Local 0)) (apply (variable (Local 1)) (variable (Local 2)))) `shouldBe` "a (b c)"
 
+    it "associates lambdas to the right without parentheses" $
+      show identity `shouldBe` "λ b : Type . λ a : b . a"
+
   describe "digits" $ do
     it "zero is zero in base 10" $
       digits 10 0 `shouldBe` [0]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -38,6 +38,9 @@ main = hspec $ do
     it "associates lambdas to the right without parentheses" $
       show identity `shouldBe` "λ b : Type . λ a : b . a"
 
+    it "renders lambdas without abstractions as function types" $
+      show (_type' --> _type') `shouldBe` "Type → Type"
+
   describe "digits" $ do
     it "zero is zero in base 10" $
       digits 10 0 `shouldBe` [0]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -29,6 +29,9 @@ main = hspec $ do
     it "bare applications are unparenthesized" $
       show (apply (variable (Local 0)) (variable (Local 1))) `shouldBe` "a b"
 
+    it "associates applications to the left without parentheses" $
+      show (apply (apply (variable (Local 0)) (variable (Local 1))) (variable (Local 2))) `shouldBe` "a b c"
+
   describe "digits" $ do
     it "zero is zero in base 10" $
       digits 10 0 `shouldBe` [0]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -23,6 +23,9 @@ main = hspec $ do
     it "shows Type (n > 10) with subscript digits" $
       show (_type 12) `shouldBe` "Type₁₂"
 
+    it "shows local variables as letters" $
+      show (variable (Local 0) :: Term Expression) `shouldBe` "a"
+
   describe "digits" $ do
     it "zero is zero in base 10" $
       digits 10 0 `shouldBe` [0]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -26,6 +26,9 @@ main = hspec $ do
     it "shows local variables as letters" $
       show (variable (Local 0) :: Term Expression) `shouldBe` "a"
 
+    it "bare applications are unparenthesized" $
+      show (apply (variable (Local 0)) (variable (Local 1))) `shouldBe` "a b"
+
   describe "digits" $ do
     it "zero is zero in base 10" $
       digits 10 0 `shouldBe` [0]


### PR DESCRIPTION
Pretty-printing for terms.
- [x] Parenthesize right-nested applications.
- [x] Parenthesize left-nested lambdas.
- [x] Show lambdas as function types when they don’t use their bound variables.
- ~~Show lambdas as e.g. `(x : A) → B x` when they’re definitely types.~~ Not in this PR.
