### PR TITLE
Unification produces type diffs

### DIFF
--- a/Surface.cabal
+++ b/Surface.cabal
@@ -21,6 +21,7 @@ library
                      , Data.Name
                      , Data.Name.Internal
                      , Data.Term
+                     , Data.Term.Types
                      , Data.Typing
                      , Data.Unification
                      , Surface

--- a/src/Data/Binding.hs
+++ b/src/Data/Binding.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Data.Binding where
 
 import Data.Name
@@ -7,4 +7,4 @@ data Binding f term
   = Variable Name
   | Abstraction Name term
   | Expression (f term)
-  deriving (Show, Eq, Functor, Foldable)
+  deriving (Show, Eq, Functor, Foldable, Traversable)

--- a/src/Data/Expression.hs
+++ b/src/Data/Expression.hs
@@ -8,14 +8,8 @@ data Expression recur
   | Lambda recur recur
   deriving (Functor, Show, Eq, Foldable, Traversable)
 
-instance Unifiable recur => Unifiable (Expression recur) where
-  unify expected actual = case (expected, actual) of
-    (Application a1 b1, Application a2 b2) -> do
-      a <- unify a1 a2
-      b <- unify b1 b2
-      return $ Application a b
-    (Lambda a1 b1, Lambda a2 b2) -> do
-      a <- unify a1 a2
-      b <- unify b1 b2
-      return $ Lambda a b
+instance Unifiable Expression where
+  unifyBy f expected actual = case (expected, actual) of
+    (Application a1 b1, Application a2 b2) -> Just $ Application (f a1 a2) (f b1 b2)
+    (Lambda a1 b1, Lambda a2 b2) -> Just $ Lambda (f a1 a2) (f b1 b2)
     _ -> Nothing

--- a/src/Data/Expression.hs
+++ b/src/Data/Expression.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Data.Expression where
 
 import Data.Unification
@@ -6,7 +6,7 @@ import Data.Unification
 data Expression recur
   = Application recur recur
   | Lambda recur recur
-  deriving (Functor, Show, Eq, Foldable)
+  deriving (Functor, Show, Eq, Foldable, Traversable)
 
 instance Unifiable recur => Unifiable (Expression recur) where
   unify expected actual = case (expected, actual) of

--- a/src/Data/Module.hs
+++ b/src/Data/Module.hs
@@ -1,7 +1,7 @@
 module Data.Module where
 
 import Data.Expression
-import Data.Term
+import Data.Term.Types
 import qualified Data.Map as Map
 
 data Module = Module (Map.Map String (Term Expression))

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -78,7 +78,7 @@ rename old new term@(Term _ typeChecker binding) = case binding of
   Implicit -> term
 
 renameUnification :: (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Name -> Name -> Unification f -> Unification f
-renameUnification old new (Unification out) = Unification out
+renameUnification old new (Unification out) = Unification $ renameTypingBy renameUnification old new out
 renameUnification old new (Conflict expected actual) = Conflict (rename old new expected) (rename old new actual)
 
 renameTypingBy :: Functor f => (Name -> Name -> g f -> g f) -> Name -> Name -> Typing (Binding f) (g f) -> Typing (Binding f) (g f)

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -14,13 +14,23 @@ type Context term = Map.Map Name term
 
 type TypeChecker term = Context term -> Result term
 
-data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term f), out :: Typing (Binding f) (Term f) }
+data Fix' term f = Fix' (Set.Set Name) (TypeChecker term) (Typing (Binding f) term)
+newtype Term f = Term (Fix' (Term f) f)
+
+freeVariables :: Term f -> Set.Set Name
+freeVariables (Term (Fix' freeVariables _ _)) = freeVariables
+
+typeOf :: Term f -> TypeChecker (Term f)
+typeOf (Term (Fix' _ typeOf _)) = typeOf
+
+out :: Term f -> Typing (Binding f) (Term f)
+out (Term (Fix' _ _ out)) = out
 
 variable :: Name -> Term f
-variable name = Term (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))
+variable name = Term $ Fix' (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))
 
 abstraction :: Name -> Term f -> Term f
-abstraction name scope = Term (Set.delete name $ freeVariables scope) (typeOf scope) (Binding (Abstraction name scope))
+abstraction name scope = Term $ Fix' (Set.delete name $ freeVariables scope) (typeOf scope) (Binding (Abstraction name scope))
 
 abstract :: (Foldable f, Functor f) => (Term f -> Term f) -> Term f
 abstract f = abstraction name scope
@@ -33,14 +43,14 @@ annotation term type' = checkedTyping (check type' term) $ Annotation term type'
 
 
 checkedAbstraction :: Name -> TypeChecker (Term f) -> Term f -> Term f
-checkedAbstraction name typeChecker scope = Term (Set.delete name $ freeVariables scope) typeChecker (Binding (Abstraction name scope))
+checkedAbstraction name typeChecker scope = Term $ Fix' (Set.delete name $ freeVariables scope) typeChecker (Binding (Abstraction name scope))
 
 -- | Constructs an abstraction term with a name, the type of that name, and the scope which the name is available within.
 typedAbstraction :: Name -> Term f -> Term f -> Term f
 typedAbstraction name type' scope = checkedAbstraction name (typeOf scope . Map.insert name type') scope
 
 checkedTyping :: Foldable f => TypeChecker (Term f) -> Typing (Binding f) (Term f) -> Term f
-checkedTyping typeChecker t = Term (foldMap freeVariables t) typeChecker t
+checkedTyping typeChecker t = Term $ Fix' (foldMap freeVariables t) typeChecker t
 
 checkedBinding :: Foldable f => TypeChecker (Term f) -> Binding f (Term f) -> Term f
 checkedBinding typeChecker = checkedTyping typeChecker . Binding
@@ -49,13 +59,13 @@ checkedExpression :: Foldable f => TypeChecker (Term f) -> f (Term f) -> Term f
 checkedExpression typeChecker = checkedBinding typeChecker . Expression
 
 _type :: Foldable f => Int -> Term f
-_type n = Term mempty (const . Right . _type $ n + 1) $ Type n
+_type n = Term $ Fix' mempty (const . Right . _type $ n + 1) $ Type n
 
 _type' :: Foldable f => Term f
 _type' = _type 0
 
 implicit :: Term f
-implicit = Term mempty (const $ Right implicit) Implicit
+implicit = Term $ Fix' mempty (const $ Right implicit) Implicit
 
 -- | Constructs a typechecker which verifies that the given type is inhabited by the given term.
 check :: (Show (Term f), Unifiable (Term f)) => Term f -> Term f -> TypeChecker (Term f)
@@ -75,7 +85,7 @@ maxBoundVariable = cata $ \ t -> case t of
 
 rename :: (Foldable f, Functor f, Show (Term f), Unifiable (f (Term f)), Eq (f (Term f))) => Name -> Name -> Term f -> Term f
 rename old new term | old == new = term
-rename old new term@(Term _ typeChecker binding) = case binding of
+rename old new term@(Term (Fix' _ typeChecker binding)) = case binding of
   Binding (Variable name) -> if name == old then variable new else term
   Binding (Abstraction name scope) -> if name == old then term else checkedAbstraction name typeChecker (rename old new scope)
   Binding (Expression body) -> checkedExpression typeChecker $ rename old new <$> body
@@ -86,7 +96,7 @@ rename old new term@(Term _ typeChecker binding) = case binding of
 
 substitute :: (Foldable f, Functor f, Show (Term f), Unifiable (f (Term f)), Eq (f (Term f))) => Name -> Term f -> Term f -> Term f
 substitute name with term | with == variable name = term
-substitute name with term@(Term _ typeChecker binding) = case binding of
+substitute name with term@(Term (Fix' _ typeChecker binding)) = case binding of
   Binding (Variable v) -> if name == v then with else variable v
   Binding (Abstraction bound scope) -> if name == bound then term else abstraction bound' scope'
     where bound' = fresh (Set.union (freeVariables term) (freeVariables with)) bound
@@ -103,7 +113,7 @@ applySubstitution withTerm body = case out body of
   _ -> body
 
 extendContext :: Term f -> Context (Term f) -> Term f -> Context (Term f)
-extendContext type' context (Term _ _ binding) = case binding of
+extendContext type' context (Term (Fix' _ _ binding)) = case binding of
   Binding (Abstraction name _) -> Map.insert name type' context
   _ -> context
 

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -134,6 +134,7 @@ unify expected actual = case (out expected, out actual) of
   (Type _, Type _) -> into expected
   (Annotation term1 type1, Annotation term2 type2) -> Unification (Annotation (unify term1 term2) (unify type1 type2))
 
+  (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) | name1 == name2 -> Unification (Binding $ Abstraction name1 (unify scope1 scope2))
   (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) -> Unification (Binding $ Abstraction name1 (rename' name name1 (unify (rename name1 name scope1) (rename name2 name scope2))))
     where name = if name1 == name2
             then name1

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -12,6 +12,9 @@ import qualified Data.Set as Set
 instance (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Renameable (Term f) where
   rename' = rename
 
+instance Renameable (Unification f) where
+  rename' old new (Unification out) = Unification out
+  rename' _ _ u = u
 
 variable :: Name -> Term f
 variable name = Term (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -9,13 +9,6 @@ import Data.Unification
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
-instance (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Renameable (Term f) where
-  rename' = rename
-
-instance (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Renameable (Unification f) where
-  rename' old new (Unification out) = Unification out
-  rename' old new (Conflict expected actual) = Conflict (rename old new expected) (rename old new actual)
-
 variable :: Name -> Term f
 variable name = Term (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))
 

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -9,15 +9,6 @@ import Data.Unification
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
-freeVariables :: Term f -> Set.Set Name
-freeVariables (Term (Term' freeVariables _ _)) = freeVariables
-
-typeOf :: Term f -> TypeChecker (Term f)
-typeOf (Term (Term' _ typeOf _)) = typeOf
-
-out :: Term f -> Typing (Binding f) (Term f)
-out (Term (Term' _ _ out)) = out
-
 variable :: Name -> Term f
 variable name = Term $ Term' (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))
 

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -136,9 +136,7 @@ unify expected actual = case (out expected, out actual) of
 
   (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) | name1 == name2 -> Unification (Binding $ Abstraction name1 (unify scope1 scope2))
   (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) -> Unification (Binding $ Abstraction name1 (rename' name name1 (unify (rename name1 name scope1) (rename name2 name scope2))))
-    where name = if name1 == name2
-            then name1
-            else pick $ freeVariables scope1 `mappend` freeVariables scope2
+    where name = pick $ freeVariables scope1 `mappend` freeVariables scope2
 
   (Binding (Abstraction name scope), _) | Set.notMember name (freeVariables scope) -> unify scope actual
   (_, Binding (Abstraction name scope)) | Set.notMember name (freeVariables scope) -> unify expected scope

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -88,8 +88,7 @@ renameTypingBy f old new typing = case typing of
   Binding (Abstraction name scope) -> if name == old then typing else Binding $ Abstraction name (f scope)
   Binding (Expression body) -> Binding $ Expression $ f <$> body
 
-  Annotation a b -> let a' = f a
-                        b' = f b in Annotation a' b'
+  Annotation a b -> Annotation (f a) (f b)
 
   Type _ -> typing
   Implicit -> typing

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -9,6 +9,10 @@ import Data.Unification
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
+instance (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Renameable (Term f) where
+  rename' = rename
+
+
 variable :: Name -> Term f
 variable name = Term (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))
 

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -4,18 +4,10 @@ module Data.Term where
 import Data.Binding
 import Data.Name
 import Data.Typing
+import Data.Term.Types
 import Data.Unification
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-
-type Result a = Either String a
-
-type Context term = Map.Map Name term
-
-type TypeChecker term = Context term -> Result term
-
-data Term' term f = Term' (Set.Set Name) (TypeChecker term) (Typing (Binding f) term)
-newtype Term f = Term (Term' (Term f) f)
 
 freeVariables :: Term f -> Set.Set Name
 freeVariables (Term (Term' freeVariables _ _)) = freeVariables

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -10,9 +10,9 @@ import qualified Data.Set as Set
 
 type Result a = Either String a
 
-type Context f = Map.Map Name (Term f)
+type Context term = Map.Map Name term
 
-type TypeChecker f = Context f -> Result (Term f)
+type TypeChecker f = Context (Term f) -> Result (Term f)
 
 data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker f, out :: Typing (Binding f) (Term f) }
 
@@ -102,7 +102,7 @@ applySubstitution withTerm body = case out body of
   Binding (Abstraction name inScope) -> substitute name withTerm inScope
   _ -> body
 
-extendContext :: Term f -> Context f -> Term f -> Context f
+extendContext :: Term f -> Context (Term f) -> Term f -> Context (Term f)
 extendContext type' context (Term _ _ binding) = case binding of
   Binding (Abstraction name _) -> Map.insert name type' context
   _ -> context

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -82,6 +82,7 @@ renameUnification old new (Unification out) = Unification out
 renameUnification old new (Conflict expected actual) = Conflict (rename old new expected) (rename old new actual)
 
 renameTypingBy :: Functor f => (Name -> Name -> g f -> g f) -> Name -> Name -> Typing (Binding f) (g f) -> Typing (Binding f) (g f)
+renameTypingBy _ old new typing | old == new = typing
 renameTypingBy f old new typing = case typing of
   Binding (Variable name) -> if name == old then Binding (Variable new) else typing
   Binding (Abstraction name scope) -> if name == old then typing else Binding $ Abstraction name (f old new scope)

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -120,9 +120,6 @@ byUnifying a b context = do
   b' <- b context
   maybe (Left "couldn’t unify") Right $ unify a' b'
 
-instance Eq (f (Term f)) => Eq (Term f) where
-  a == b = freeVariables a == freeVariables b && out a == out b
-
 instance (Functor f, Foldable f, Show (Term f), Eq (f (Term f)), Unifiable (f (Term f))) => Unifiable (Term f) where
   unify expected actual = case (out expected, out actual) of
     (a, b) | a == b -> Just expected

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -132,10 +132,7 @@ unify expected actual = case (out expected, out actual) of
   (Implicit, _) -> into actual
 
   (Type _, Type _) -> into expected
-  (Annotation term1 type1, Annotation term2 type2) -> do
-    let term = unify term1 term2
-    let type' = unify type1 type2
-    Unification (Annotation term type')
+  (Annotation term1 type1, Annotation term2 type2) -> Unification (Annotation (unify term1 term2) (unify type1 type2))
 
   (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) -> Unification (Binding $ Abstraction name1 (rename' name name1 (unify (rename name1 name scope1) (rename name2 name scope2))))
     where name = if name1 == name2

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -12,9 +12,9 @@ import qualified Data.Set as Set
 instance (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Renameable (Term f) where
   rename' = rename
 
-instance Renameable (Unification f) where
+instance (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Renameable (Unification f) where
   rename' old new (Unification out) = Unification out
-  rename' _ _ u = u
+  rename' old new (Conflict expected actual) = Conflict (rename old new expected) (rename old new actual)
 
 variable :: Name -> Term f
 variable name = Term (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -137,12 +137,10 @@ unify expected actual = case (out expected, out actual) of
     let type' = unify type1 type2
     Unification (Annotation term type')
 
-  (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) -> do
-    let name = if name1 == name2
-        then name1
-        else pick $ freeVariables scope1 `mappend` freeVariables scope2
-    let scope = unify (rename name1 name scope1) (rename name2 name scope2)
-    Unification (Binding $ Abstraction name1 (rename' name name1 scope))
+  (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) -> Unification (Binding $ Abstraction name1 (rename' name name1 (unify (rename name1 name scope1) (rename name2 name scope2))))
+    where name = if name1 == name2
+            then name1
+            else pick $ freeVariables scope1 `mappend` freeVariables scope2
 
   (Binding (Abstraction name scope), _) | Set.notMember name (freeVariables scope) -> unify scope actual
   (_, Binding (Abstraction name scope)) | Set.notMember name (freeVariables scope) -> unify expected scope

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -142,7 +142,7 @@ unify expected actual = case (out expected, out actual) of
   (Annotation term1 type1, Annotation term2 type2) -> Unification (Annotation (unify term1 term2) (unify type1 type2))
 
   (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) | name1 == name2 -> Unification (Binding $ Abstraction name1 (unify scope1 scope2))
-  (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) -> Unification (Binding $ Abstraction name1 (rename' name name1 (unify (rename name1 name scope1) (rename name2 name scope2))))
+  (Binding (Abstraction name1 scope1), Binding (Abstraction name2 scope2)) -> Unification (Binding $ Abstraction name1 (renameUnification name name1 (unify (rename name1 name scope1) (rename name2 name scope2))))
     where name = pick $ freeVariables scope1 `mappend` freeVariables scope2
 
   (Binding (Abstraction name scope), _) | Set.notMember name (freeVariables scope) -> unify scope actual

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -10,10 +10,10 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 
 variable :: Name -> Term f
-variable name = Term $ Term' (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))
+variable name = Term (Set.singleton name) (maybe (Left $ "Unexpectedly free variable " ++ show name) Right . Map.lookup name) (Binding (Variable name))
 
 abstraction :: Name -> Term f -> Term f
-abstraction name scope = Term $ Term' (Set.delete name $ freeVariables scope) (typeOf scope) (Binding (Abstraction name scope))
+abstraction name scope = Term (Set.delete name $ freeVariables scope) (typeOf scope) (Binding (Abstraction name scope))
 
 abstract :: (Foldable f, Functor f) => (Term f -> Term f) -> Term f
 abstract f = abstraction name scope
@@ -26,14 +26,14 @@ annotation term type' = checkedTyping (check type' term) $ Annotation term type'
 
 
 checkedAbstraction :: Name -> TypeChecker (Term f) -> Term f -> Term f
-checkedAbstraction name typeChecker scope = Term $ Term' (Set.delete name $ freeVariables scope) typeChecker (Binding (Abstraction name scope))
+checkedAbstraction name typeChecker scope = Term (Set.delete name $ freeVariables scope) typeChecker (Binding (Abstraction name scope))
 
 -- | Constructs an abstraction term with a name, the type of that name, and the scope which the name is available within.
 typedAbstraction :: Name -> Term f -> Term f -> Term f
 typedAbstraction name type' scope = checkedAbstraction name (typeOf scope . Map.insert name type') scope
 
 checkedTyping :: Foldable f => TypeChecker (Term f) -> Typing (Binding f) (Term f) -> Term f
-checkedTyping typeChecker t = Term $ Term' (foldMap freeVariables t) typeChecker t
+checkedTyping typeChecker t = Term (foldMap freeVariables t) typeChecker t
 
 checkedBinding :: Foldable f => TypeChecker (Term f) -> Binding f (Term f) -> Term f
 checkedBinding typeChecker = checkedTyping typeChecker . Binding
@@ -42,13 +42,13 @@ checkedExpression :: Foldable f => TypeChecker (Term f) -> f (Term f) -> Term f
 checkedExpression typeChecker = checkedBinding typeChecker . Expression
 
 _type :: Foldable f => Int -> Term f
-_type n = Term $ Term' mempty (const . Right . _type $ n + 1) $ Type n
+_type n = Term mempty (const . Right . _type $ n + 1) $ Type n
 
 _type' :: Foldable f => Term f
 _type' = _type 0
 
 implicit :: Term f
-implicit = Term $ Term' mempty (const $ Right implicit) Implicit
+implicit = Term mempty (const $ Right implicit) Implicit
 
 -- | Constructs a typechecker which verifies that the given type is inhabited by the given term.
 check :: (Show (Term f), Unifiable (Term f)) => Term f -> Term f -> TypeChecker (Term f)
@@ -68,7 +68,7 @@ maxBoundVariable = cata $ \ t -> case t of
 
 rename :: (Foldable f, Functor f, Show (Term f), Unifiable (f (Term f)), Eq (f (Term f))) => Name -> Name -> Term f -> Term f
 rename old new term | old == new = term
-rename old new term@(Term (Term' _ typeChecker binding)) = case binding of
+rename old new term@(Term _ typeChecker binding) = case binding of
   Binding (Variable name) -> if name == old then variable new else term
   Binding (Abstraction name scope) -> if name == old then term else checkedAbstraction name typeChecker (rename old new scope)
   Binding (Expression body) -> checkedExpression typeChecker $ rename old new <$> body
@@ -79,7 +79,7 @@ rename old new term@(Term (Term' _ typeChecker binding)) = case binding of
 
 substitute :: (Foldable f, Functor f, Show (Term f), Unifiable (f (Term f)), Eq (f (Term f))) => Name -> Term f -> Term f -> Term f
 substitute name with term | with == variable name = term
-substitute name with term@(Term (Term' _ typeChecker binding)) = case binding of
+substitute name with term@(Term _ typeChecker binding) = case binding of
   Binding (Variable v) -> if name == v then with else variable v
   Binding (Abstraction bound scope) -> if name == bound then term else abstraction bound' scope'
     where bound' = fresh (Set.union (freeVariables term) (freeVariables with)) bound
@@ -96,7 +96,7 @@ applySubstitution withTerm body = case out body of
   _ -> body
 
 extendContext :: Term f -> Context (Term f) -> Term f -> Context (Term f)
-extendContext type' context (Term (Term' _ _ binding)) = case binding of
+extendContext type' context (Term _ _ binding) = case binding of
   Binding (Abstraction name _) -> Map.insert name type' context
   _ -> context
 

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -84,6 +84,10 @@ rename old new term@(Term _ typeChecker binding) = case binding of
   Type _ -> term
   Implicit -> term
 
+renameUnification :: (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Name -> Name -> Unification f -> Unification f
+renameUnification old new (Unification out) = Unification out
+renameUnification old new (Conflict expected actual) = Conflict (rename old new expected) (rename old new actual)
+
 substitute :: (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Name -> Term f -> Term f -> Term f
 substitute name with term | with == variable name = term
 substitute name with term@(Term _ typeChecker binding) = case binding of

--- a/src/Data/Term.hs
+++ b/src/Data/Term.hs
@@ -78,18 +78,18 @@ rename old new term@(Term _ typeChecker binding) = case binding of
   Implicit -> term
 
 renameUnification :: (Show (Term f), Unifiable f, Traversable f, Eq (f (Term f))) => Name -> Name -> Unification f -> Unification f
-renameUnification old new (Unification out) = Unification $ renameTypingBy renameUnification old new out
+renameUnification old new (Unification out) = Unification $ renameTypingBy (renameUnification old new) old new out
 renameUnification old new (Conflict expected actual) = Conflict (rename old new expected) (rename old new actual)
 
-renameTypingBy :: Functor f => (Name -> Name -> g f -> g f) -> Name -> Name -> Typing (Binding f) (g f) -> Typing (Binding f) (g f)
+renameTypingBy :: Functor f => (g f -> g f) -> Name -> Name -> Typing (Binding f) (g f) -> Typing (Binding f) (g f)
 renameTypingBy _ old new typing | old == new = typing
 renameTypingBy f old new typing = case typing of
   Binding (Variable name) -> if name == old then Binding (Variable new) else typing
-  Binding (Abstraction name scope) -> if name == old then typing else Binding $ Abstraction name (f old new scope)
-  Binding (Expression body) -> Binding $ Expression $ f old new <$> body
+  Binding (Abstraction name scope) -> if name == old then typing else Binding $ Abstraction name (f scope)
+  Binding (Expression body) -> Binding $ Expression $ f <$> body
 
-  Annotation a b -> let a' = f old new a
-                        b' = f old new b in Annotation a' b'
+  Annotation a b -> let a' = f a
+                        b' = f b in Annotation a' b'
 
   Type _ -> typing
   Implicit -> typing

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -16,3 +16,6 @@ data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term 
 
 data Unification f = Unification (Typing (Binding f) (Unification f)) | Replace (Term f) (Term f)
 
+expected :: Functor f => Unification f -> Term f
+expected (Replace expected _) = expected
+expected (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (expected <$> out)

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -17,6 +17,3 @@ data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term 
 
 instance Eq (f (Term f)) => Eq (Term f) where
   a == b = freeVariables a == freeVariables b && out a == out b
-
-class Renameable t where
-  rename' :: Name -> Name -> t -> t

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -13,22 +13,3 @@ type Context term = Map.Map Name term
 type TypeChecker term = Context term -> Result term
 
 data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term f), out :: Typing (Binding f) (Term f) }
-
-data Unification f = Unification (Typing (Binding f) (Unification f)) | Conflict (Term f) (Term f)
-
-expected :: Functor f => Unification f -> Term f
-expected (Conflict expected _) = expected
-expected (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (expected <$> out)
-
-actual :: Functor f => Unification f -> Term f
-actual (Conflict _ actual) = actual
-actual (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (actual <$> out)
-
-unified :: Traversable f => Unification f -> Maybe (Term f)
-unified (Conflict _ _) = Nothing
-unified (Unification out) = do
-  out <- mapM unified out
-  return $ Term Set.empty (const $ Left "Unification does not preserve typecheckers") out
-
-into :: Functor f => Term f -> Unification f
-into term = Unification $ into <$> out term

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE UndecidableInstances #-}
 module Data.Term.Types where
 
 import Data.Binding
@@ -13,3 +14,6 @@ type Context term = Map.Map Name term
 type TypeChecker term = Context term -> Result term
 
 data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term f), out :: Typing (Binding f) (Term f) }
+
+instance Eq (f (Term f)) => Eq (Term f) where
+  a == b = freeVariables a == freeVariables b && out a == out b

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -14,3 +14,5 @@ type TypeChecker term = Context term -> Result term
 
 data Term' term f = Term' (Set.Set Name) (TypeChecker term) (Typing (Binding f) term)
 newtype Term f = Term (Term' (Term f) f)
+
+data Unification f = Unification (Term' (Unification f) f) | Replace (Term f) (Term f)

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -29,3 +29,6 @@ unified (Conflict _ _) = Nothing
 unified (Unification out) = do
   out <- mapM unified out
   return $ Term Set.empty (const $ Left "Unification does not preserve typecheckers") out
+
+into :: Functor f => Term f -> Unification f
+into term = Unification $ into <$> out term

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -19,3 +19,7 @@ data Unification f = Unification (Typing (Binding f) (Unification f)) | Replace 
 expected :: Functor f => Unification f -> Term f
 expected (Replace expected _) = expected
 expected (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (expected <$> out)
+
+actual :: Functor f => Unification f -> Term f
+actual (Replace _ actual) = actual
+actual (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (actual <$> out)

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -12,17 +12,7 @@ type Context term = Map.Map Name term
 
 type TypeChecker term = Context term -> Result term
 
-data Term' term f = Term' { freeVariables' :: Set.Set Name, typeOf' :: TypeChecker term, out' :: Typing (Binding f) term }
-newtype Term f = Term (Term' (Term f) f)
+data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term f), out :: Typing (Binding f) (Term f) }
 
-freeVariables :: Term f -> Set.Set Name
-freeVariables (Term (Term' freeVariables _ _)) = freeVariables
+data Unification f = Unification (Typing (Binding f) (Unification f)) | Replace (Term f) (Term f)
 
-typeOf :: Term f -> TypeChecker (Term f)
-typeOf (Term (Term' _ typeOf _)) = typeOf
-
-out :: Term f -> Typing (Binding f) (Term f)
-out (Term (Term' _ _ out)) = out
-
-
-data Unification f = Unification (Term' (Unification f) f) | Replace (Term f) (Term f)

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -12,7 +12,7 @@ type Context term = Map.Map Name term
 
 type TypeChecker term = Context term -> Result term
 
-data Term' term f = Term' (Set.Set Name) (TypeChecker term) (Typing (Binding f) term)
+data Term' term f = Term' { freeVariables' :: Set.Set Name, typeOf' :: TypeChecker term, out' :: Typing (Binding f) term }
 newtype Term f = Term (Term' (Term f) f)
 
 freeVariables :: Term f -> Set.Set Name

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -1,0 +1,1 @@
+module Data.Term.Types where

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -17,3 +17,6 @@ data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term 
 
 instance Eq (f (Term f)) => Eq (Term f) where
   a == b = freeVariables a == freeVariables b && out a == out b
+
+class Renameable t where
+  rename' :: Name -> Name -> t -> t

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -23,3 +23,9 @@ expected (Unification out) = Term Set.empty (const $ Left "Unification does not 
 actual :: Functor f => Unification f -> Term f
 actual (Replace _ actual) = actual
 actual (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (actual <$> out)
+
+unified :: Traversable f => Unification f -> Maybe (Term f)
+unified (Replace _ _) = Nothing
+unified (Unification out) = do
+  out <- mapM unified out
+  return $ Term Set.empty (const $ Left "Unification does not preserve typecheckers") out

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -14,18 +14,18 @@ type TypeChecker term = Context term -> Result term
 
 data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term f), out :: Typing (Binding f) (Term f) }
 
-data Unification f = Unification (Typing (Binding f) (Unification f)) | Replace (Term f) (Term f)
+data Unification f = Unification (Typing (Binding f) (Unification f)) | Conflict (Term f) (Term f)
 
 expected :: Functor f => Unification f -> Term f
-expected (Replace expected _) = expected
+expected (Conflict expected _) = expected
 expected (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (expected <$> out)
 
 actual :: Functor f => Unification f -> Term f
-actual (Replace _ actual) = actual
+actual (Conflict _ actual) = actual
 actual (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (actual <$> out)
 
 unified :: Traversable f => Unification f -> Maybe (Term f)
-unified (Replace _ _) = Nothing
+unified (Conflict _ _) = Nothing
 unified (Unification out) = do
   out <- mapM unified out
   return $ Term Set.empty (const $ Left "Unification does not preserve typecheckers") out

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -1,1 +1,16 @@
 module Data.Term.Types where
+
+import Data.Binding
+import Data.Name
+import Data.Typing
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+type Result a = Either String a
+
+type Context term = Map.Map Name term
+
+type TypeChecker term = Context term -> Result term
+
+data Term' term f = Term' (Set.Set Name) (TypeChecker term) (Typing (Binding f) term)
+newtype Term f = Term (Term' (Term f) f)

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -15,4 +15,14 @@ type TypeChecker term = Context term -> Result term
 data Term' term f = Term' (Set.Set Name) (TypeChecker term) (Typing (Binding f) term)
 newtype Term f = Term (Term' (Term f) f)
 
+freeVariables :: Term f -> Set.Set Name
+freeVariables (Term (Term' freeVariables _ _)) = freeVariables
+
+typeOf :: Term f -> TypeChecker (Term f)
+typeOf (Term (Term' _ typeOf _)) = typeOf
+
+out :: Term f -> Typing (Binding f) (Term f)
+out (Term (Term' _ _ out)) = out
+
+
 data Unification f = Unification (Term' (Unification f) f) | Replace (Term f) (Term f)

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -17,9 +17,6 @@ data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term 
 
 data Unification f = Unification (Typing (Binding f) (Unification f)) | Conflict (Term f) (Term f)
 
-deriving instance (Eq (Term f), Eq (f (Unification f))) => Eq (Unification f)
-deriving instance (Show (Term f), Show (f (Unification f))) => Show (Unification f)
-
 expected :: Functor f => Unification f -> Term f
 expected (Conflict expected _) = expected
 expected (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (expected <$> out)
@@ -40,3 +37,6 @@ into term = Unification $ into <$> out term
 
 instance Eq (f (Term f)) => Eq (Term f) where
   a == b = freeVariables a == freeVariables b && out a == out b
+
+deriving instance (Eq (Term f), Eq (f (Unification f))) => Eq (Unification f)
+deriving instance (Show (Term f), Show (f (Unification f))) => Show (Unification f)

--- a/src/Data/Term/Types.hs
+++ b/src/Data/Term/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving, UndecidableInstances #-}
 module Data.Term.Types where
 
 import Data.Binding
@@ -14,6 +14,29 @@ type Context term = Map.Map Name term
 type TypeChecker term = Context term -> Result term
 
 data Term f = Term { freeVariables :: Set.Set Name, typeOf :: TypeChecker (Term f), out :: Typing (Binding f) (Term f) }
+
+data Unification f = Unification (Typing (Binding f) (Unification f)) | Conflict (Term f) (Term f)
+
+deriving instance (Eq (Term f), Eq (f (Unification f))) => Eq (Unification f)
+deriving instance (Show (Term f), Show (f (Unification f))) => Show (Unification f)
+
+expected :: Functor f => Unification f -> Term f
+expected (Conflict expected _) = expected
+expected (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (expected <$> out)
+
+actual :: Functor f => Unification f -> Term f
+actual (Conflict _ actual) = actual
+actual (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (actual <$> out)
+
+unified :: Traversable f => Unification f -> Maybe (Term f)
+unified (Conflict _ _) = Nothing
+unified (Unification out) = do
+  out <- mapM unified out
+  return $ Term Set.empty (const $ Left "Unification does not preserve typecheckers") out
+
+into :: Functor f => Term f -> Unification f
+into term = Unification $ into <$> out term
+
 
 instance Eq (f (Term f)) => Eq (Term f) where
   a == b = freeVariables a == freeVariables b && out a == out b

--- a/src/Data/Typing.hs
+++ b/src/Data/Typing.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Data.Typing where
 
 data Typing f term
@@ -6,4 +6,4 @@ data Typing f term
   | Annotation term term
   | Binding (f term)
   | Implicit
-  deriving (Show, Eq, Functor, Foldable)
+  deriving (Show, Eq, Functor, Foldable, Traversable)

--- a/src/Data/Unification.hs
+++ b/src/Data/Unification.hs
@@ -31,3 +31,7 @@ unified (Unification out) = do
 
 into :: Functor f => Term f -> Unification f
 into term = Unification $ into <$> out term
+
+instance Renameable (Unification f) where
+  rename' old new (Unification out) = Unification out
+  rename' _ _ u = u

--- a/src/Data/Unification.hs
+++ b/src/Data/Unification.hs
@@ -13,6 +13,7 @@ class Unifiable a where
 data Unification f = Unification (Typing (Binding f) (Unification f)) | Conflict (Term f) (Term f)
 
 deriving instance (Eq (Term f), Eq (f (Unification f))) => Eq (Unification f)
+deriving instance (Show (Term f), Show (f (Unification f))) => Show (Unification f)
 
 expected :: Functor f => Unification f -> Term f
 expected (Conflict expected _) = expected

--- a/src/Data/Unification.hs
+++ b/src/Data/Unification.hs
@@ -6,8 +6,8 @@ import Data.Typing
 import Data.Term.Types
 import qualified Data.Set as Set
 
-class Unifiable a where
-  unify :: a -> a -> Maybe a
+class Unifiable e where
+  unifyBy :: (f e -> f e -> Unification e) -> e (f e) -> e (f e) -> Maybe (e (Unification e))
 
 
 data Unification f = Unification (Typing (Binding f) (Unification f)) | Conflict (Term f) (Term f)

--- a/src/Data/Unification.hs
+++ b/src/Data/Unification.hs
@@ -1,33 +1,6 @@
-{-# LANGUAGE StandaloneDeriving, UndecidableInstances #-}
 module Data.Unification where
 
-import Data.Binding
-import Data.Typing
 import Data.Term.Types
-import qualified Data.Set as Set
 
 class Unifiable e where
   unifyBy :: (f e -> f e -> Unification e) -> e (f e) -> e (f e) -> Maybe (e (Unification e))
-
-
-data Unification f = Unification (Typing (Binding f) (Unification f)) | Conflict (Term f) (Term f)
-
-deriving instance (Eq (Term f), Eq (f (Unification f))) => Eq (Unification f)
-deriving instance (Show (Term f), Show (f (Unification f))) => Show (Unification f)
-
-expected :: Functor f => Unification f -> Term f
-expected (Conflict expected _) = expected
-expected (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (expected <$> out)
-
-actual :: Functor f => Unification f -> Term f
-actual (Conflict _ actual) = actual
-actual (Unification out) = Term Set.empty (const $ Left "Unification does not preserve typecheckers") (actual <$> out)
-
-unified :: Traversable f => Unification f -> Maybe (Term f)
-unified (Conflict _ _) = Nothing
-unified (Unification out) = do
-  out <- mapM unified out
-  return $ Term Set.empty (const $ Left "Unification does not preserve typecheckers") out
-
-into :: Functor f => Term f -> Unification f
-into term = Unification $ into <$> out term

--- a/src/Data/Unification.hs
+++ b/src/Data/Unification.hs
@@ -31,7 +31,3 @@ unified (Unification out) = do
 
 into :: Functor f => Term f -> Unification f
 into term = Unification $ into <$> out term
-
-instance Renameable (Unification f) where
-  rename' old new (Unification out) = Unification out
-  rename' _ _ u = u

--- a/src/Data/Unification.hs
+++ b/src/Data/Unification.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StandaloneDeriving, UndecidableInstances #-}
 module Data.Unification where
 
 import Data.Binding
@@ -10,6 +11,8 @@ class Unifiable a where
 
 
 data Unification f = Unification (Typing (Binding f) (Unification f)) | Conflict (Term f) (Term f)
+
+deriving instance (Eq (Term f), Eq (f (Unification f))) => Eq (Unification f)
 
 expected :: Functor f => Unification f -> Term f
 expected (Conflict expected _) = expected

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -79,7 +79,7 @@ instance Monoid a => Alternative (Either a) where
   Right a <|> _ = Right a
   _ <|> Right b = Right b
 
-checkIsType :: (Show (Term Expression), Unifiable (Term Expression), Foldable Expression) => Term Expression -> TypeChecker (Term Expression)
+checkIsType :: Term Expression -> TypeChecker (Term Expression)
 checkIsType term context = do
   actual <- typeOf term context
   expectUnifiable _type' actual <|> expectUnifiable (_type' --> _type') actual

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -64,7 +64,7 @@ apply a b = checkedExpression type' $ Application a b
           return $ applySubstitution type' body
 
 
-checkHasFunctionType :: Term Expression -> Context Expression -> Result (Term Expression, Term Expression)
+checkHasFunctionType :: Term Expression -> Context (Term Expression) -> Result (Term Expression, Term Expression)
 checkHasFunctionType term context = do
   type' <- typeOf term context
   case out type' of

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -95,8 +95,8 @@ instance Show (Term Expression) where
 
     Binding (Expression (Application (_, a) (_, b))) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
 
-    Binding (Expression (Lambda (_, type') (Term (Term' _ _ (Binding (Abstraction name term))), body))) | Set.member name (freeVariables term) -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
-    Binding (Expression (Lambda (_, type') (Term (Term' _ _ (Binding (Abstraction _ _))), body))) -> ("λ _ : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
+    Binding (Expression (Lambda (_, type') (Term _ _ (Binding (Abstraction name term)), body))) | Set.member name (freeVariables term) -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
+    Binding (Expression (Lambda (_, type') (Term _ _ (Binding (Abstraction _ _)), body))) -> ("λ _ : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
     Binding (Expression (Lambda (_, type') (_, body))) -> (wrap 3 (<) type' ++ " → " ++ wrap 3 (<=) body, 3)
 
     Implicit -> ("_", maxBound)

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -14,6 +14,7 @@ import Data.Expression as Surface'
 import Data.Name as Surface'
 import Data.Name.Internal
 import Data.Term as Surface'
+import Data.Term.Types as Surface'
 import Data.Typing as Surface'
 import Data.Unification as Surface'
 import Control.Applicative

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -94,8 +94,8 @@ instance Show (Term Expression) where
 
     Binding (Expression (Application (_, a) (_, b))) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
 
-    Binding (Expression (Lambda (_, type') (Term (Fix' _ _ (Binding (Abstraction name term))), body))) | Set.member name (freeVariables term) -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
-    Binding (Expression (Lambda (_, type') (Term (Fix' _ _ (Binding (Abstraction _ _))), body))) -> ("λ _ : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
+    Binding (Expression (Lambda (_, type') (Term (Term' _ _ (Binding (Abstraction name term))), body))) | Set.member name (freeVariables term) -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
+    Binding (Expression (Lambda (_, type') (Term (Term' _ _ (Binding (Abstraction _ _))), body))) -> ("λ _ : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
     Binding (Expression (Lambda (_, type') (_, body))) -> (wrap 3 (<) type' ++ " → " ++ wrap 3 (<=) body, 3)
 
     Implicit -> ("_", maxBound)

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -94,8 +94,8 @@ instance Show (Term Expression) where
 
     Binding (Expression (Application (_, a) (_, b))) -> (wrap 4 (<=) a ++ " " ++ wrap 4 (<) b, 4)
 
-    Binding (Expression (Lambda (_, type') (Term _ _ (Binding (Abstraction name (Term free _ _))), body))) | Set.member name free -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
-    Binding (Expression (Lambda (_, type') (Term _ _ (Binding (Abstraction _ _)), body))) -> ("λ _ : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
+    Binding (Expression (Lambda (_, type') (Term (Fix' _ _ (Binding (Abstraction name term))), body))) | Set.member name (freeVariables term) -> ("λ " ++ show name ++ " : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
+    Binding (Expression (Lambda (_, type') (Term (Fix' _ _ (Binding (Abstraction _ _))), body))) -> ("λ _ : " ++ wrap 3 (<) type' ++ " . " ++ wrap 3 (<=) body, 3)
     Binding (Expression (Lambda (_, type') (_, body))) -> (wrap 3 (<) type' ++ " → " ++ wrap 3 (<=) body, 3)
 
     Implicit -> ("_", maxBound)

--- a/src/Surface.hs
+++ b/src/Surface.hs
@@ -78,7 +78,7 @@ instance Monoid a => Alternative (Either a) where
   Right a <|> _ = Right a
   _ <|> Right b = Right b
 
-checkIsType :: (Show (Term Expression), Unifiable (Term Expression), Foldable Expression) => Term Expression -> TypeChecker Expression
+checkIsType :: (Show (Term Expression), Unifiable (Term Expression), Foldable Expression) => Term Expression -> TypeChecker (Term Expression)
 checkIsType term context = do
   actual <- typeOf term context
   expectUnifiable _type' actual <|> expectUnifiable (_type' --> _type') actual

--- a/test/Data/Term/Spec.hs
+++ b/test/Data/Term/Spec.hs
@@ -135,22 +135,22 @@ spec = do
 
   describe "unify" $ do
     prop "_ is left unit" $
-      \ term -> unify implicit term `shouldBe` Just (term :: Term Expression)
+      \ term -> unify implicit term `shouldBe` into (term :: Term Expression)
 
     prop "_ is right unit" $
-      \ term -> unify term implicit `shouldBe` Just (term :: Term Expression)
+      \ term -> unify term implicit `shouldBe` into (term :: Term Expression)
 
     prop "identical terms unify" $
-      \ term -> unify term term `shouldBe` Just (term :: Term Expression)
+      \ term -> unify term term `shouldBe` into (term :: Term Expression)
 
     prop "binding & non-binding functions unify" $
-      \ n -> unify (_type n --> _type n) (_type n `pi` const (_type n)) `shouldBe` Just (_type n --> _type n :: Term Expression)
+      \ n -> unify (_type n --> _type n) (_type n `pi` const (_type n)) `shouldBe` into (_type n --> _type n :: Term Expression)
 
     prop "equal variables unify" $
-      \ name -> unify (variable name) (variable name) `shouldBe` Just (variable name :: Term Expression)
+      \ name -> unify (variable name) (variable name) `shouldBe` into (variable name :: Term Expression)
 
     prop "abstractions over the same name unify" $
-      \ name term -> unify (abstraction name implicit) (abstraction name term) `shouldBe` Just (abstraction name term :: Term Expression)
+      \ name term -> unify (abstraction name implicit) (abstraction name term) `shouldBe` into (abstraction name term :: Term Expression)
 
 
 infer :: Term Expression -> Either String (Term Expression)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,10 +12,10 @@ main = hspec . parallel $ do
 
   describe "lambda" $ do
     it "produces binding abstractions" $
-      lambda _type' id `shouldBe` Term mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' (abstraction (Local 0) $ variable (Local 0)))
+      lambda _type' id `shouldBe` Term (Fix' mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' (abstraction (Local 0) $ variable (Local 0))))
 
     it "picks fresh names" $
-      (_type' `lambda` const (_type' `lambda` const _type')) `shouldBe` Term mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' $ abstraction (Local 1) $ Term mempty (const $ Right implicit) $ Binding $ Expression $ Lambda _type' $ abstraction (Local 0) _type')
+      (_type' `lambda` const (_type' `lambda` const _type')) `shouldBe` Term (Fix' mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' $ abstraction (Local 1) $ Term (Fix' mempty (const $ Right implicit) $ Binding $ Expression $ Lambda _type' $ abstraction (Local 0) _type')))
 
     it "rejects non-Type types" $
       typeOf (lambda _type' $ \ a -> lambda a $ \ a' -> lambda a' $ const _type') mempty `shouldSatisfy` Either.isLeft

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,10 +12,10 @@ main = hspec . parallel $ do
 
   describe "lambda" $ do
     it "produces binding abstractions" $
-      lambda _type' id `shouldBe` Term (Fix' mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' (abstraction (Local 0) $ variable (Local 0))))
+      lambda _type' id `shouldBe` Term (Term' mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' (abstraction (Local 0) $ variable (Local 0))))
 
     it "picks fresh names" $
-      (_type' `lambda` const (_type' `lambda` const _type')) `shouldBe` Term (Fix' mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' $ abstraction (Local 1) $ Term (Fix' mempty (const $ Right implicit) $ Binding $ Expression $ Lambda _type' $ abstraction (Local 0) _type')))
+      (_type' `lambda` const (_type' `lambda` const _type')) `shouldBe` Term (Term' mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' $ abstraction (Local 1) $ Term (Term' mempty (const $ Right implicit) $ Binding $ Expression $ Lambda _type' $ abstraction (Local 0) _type')))
 
     it "rejects non-Type types" $
       typeOf (lambda _type' $ \ a -> lambda a $ \ a' -> lambda a' $ const _type') mempty `shouldSatisfy` Either.isLeft

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,10 +12,10 @@ main = hspec . parallel $ do
 
   describe "lambda" $ do
     it "produces binding abstractions" $
-      lambda _type' id `shouldBe` Term (Term' mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' (abstraction (Local 0) $ variable (Local 0))))
+      lambda _type' id `shouldBe` Term mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' (abstraction (Local 0) $ variable (Local 0)))
 
     it "picks fresh names" $
-      (_type' `lambda` const (_type' `lambda` const _type')) `shouldBe` Term (Term' mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' $ abstraction (Local 1) $ Term (Term' mempty (const $ Right implicit) $ Binding $ Expression $ Lambda _type' $ abstraction (Local 0) _type')))
+      (_type' `lambda` const (_type' `lambda` const _type')) `shouldBe` Term mempty (const $ Right implicit) (Binding $ Expression $ Lambda _type' $ abstraction (Local 1) $ Term mempty (const $ Right implicit) $ Binding $ Expression $ Lambda _type' $ abstraction (Local 0) _type')
 
     it "rejects non-Type types" $
       typeOf (lambda _type' $ \ a -> lambda a $ \ a' -> lambda a' $ const _type') mempty `shouldSatisfy` Either.isLeft


### PR DESCRIPTION
- [x] Return type diffs from `unify`.
- ~~Return type diffs from `TypeChecker`.~~ Not in this PR.

`unify` returns a structure which differentiates the expected type from the actual one.
